### PR TITLE
Change default colour to magenta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- The default color is now `ansi.magenta` instead of `ansi.pink`.
+
 ## v1.1.0 - 2024-02-19
 
 - The terminal line is now reset when stopping the spinner, to avoid having a

--- a/src/spinner.gleam
+++ b/src/spinner.gleam
@@ -46,7 +46,7 @@ pub opaque type Builder {
 /// JavaScript task.
 ///
 pub fn new(text: String) -> Builder {
-  Builder(snake_frames, text, ansi.pink)
+  Builder(snake_frames, text, ansi.magenta)
 }
 
 pub fn with_frames(builder: Builder, frames: List(String)) -> Builder {


### PR DESCRIPTION
The terminal that comes with macOS still doesn't properly support RGB colours and using `ansi.pink` leads to having the text faded instead of pink.
By using `ansi.magenta` as the default we will make sure that the default spinner will display nicely even on macOS and avoid possible sources of confusion to people trying the package.

Just an example of this problem I ran into: https://github.com/lustre-labs/dev-tools/issues/11